### PR TITLE
Include original error message when API request fails

### DIFF
--- a/nounproject.js
+++ b/nounproject.js
@@ -96,7 +96,7 @@ var Client = module.exports = function (config) {
             oauth: oauth
         }, function (err, response, body) {
             if (err) {
-                callback(new Error('Noun Project API Error'));
+                callback(new Error('Noun Project API: ' + err));
             } else if (response.statusCode !== 200) {
                 callback(response.statusCode + ' HTTP response code');
             } else {


### PR DESCRIPTION
If the underlying `request` library returns an error, reveal its message in the stack trace.

For example, a connection error currently looks like this:

> Noun Project API Error

With this change, a connection error looks like this:

> Noun Project API: Error: getaddrinfo ENOTFOUND api.thenounproject.com api.thenounproject.com:80

Much more useful 😺 