### PR TITLE
Update mocha to latest and move to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "homepage": "https://github.com/rosshettel/the-noun-project",
   "dependencies": {
-    "mocha": "^5.2.0",
     "request": "^2.88.0"
+  },
+  "devDependencies": {
+    "mocha": "^9.2.1"
   }
 }


### PR DESCRIPTION
This will fix the audit vulnerabilities and address issue #11 

`
# npm audit report

minimist  <0.2.1
Severity: moderate
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
fix available via `npm audit fix --force`
Will install mocha@9.2.1, which is a breaking change
node_modules/minimist
  mkdirp  0.4.1 - 0.5.1
  Depends on vulnerable versions of minimist
  node_modules/mkdirp
    mocha  1.21.5 - 6.2.2 || 7.0.0-esm1 - 7.1.0
    Depends on vulnerable versions of mkdirp
    node_modules/mocha

3 moderate severity vulnerabilities
`